### PR TITLE
Revert 2 develop

### DIFF
--- a/tests/unit/components/project-setting-dialog.spec.js
+++ b/tests/unit/components/project-setting-dialog.spec.js
@@ -77,7 +77,7 @@ describe('ProjectSettingDialog.vue', () => {
     wrapper.vm.openDialog();
     await flushPromises();
 
-    expect(wrapper.vm.project.name).not.toBe('');
+    expect(wrapper.vm.project.name).toBe('');
     expect(wrapper.vm.project.description).toBe('');
     expect(wrapper.vm.dialog).toBeFalsy();
   });


### PR DESCRIPTION
CIツールテストにて、失敗が確認できたため、コードを戻す。