### PR TITLE
fix: ノートの編集画面において、APIにて更新処理中にユーザーが再度編集した場合、API接続完了を待って再度APIに更新処理を実行する…

### DIFF
--- a/src/views/Note.vue
+++ b/src/views/Note.vue
@@ -209,15 +209,8 @@ export default {
           )
         );
       } else if (runTask.state === taskStatePattern.running) {
-        // TODO setIntervalでrunTaskが排除されるのを待つようにするかどうか。
-        Object.assign(
-          runTask,
-          this.createTask(
-            paramId,
-            taskStatePattern.scheduled,
-            setTimeout(this.update, apiAccessInterVal, { ...this.note })
-          )
-        );
+        // 時間を置いて再度このメソッドを実行する
+        setTimeout(this.updateNote, apiAccessInterVal);
       } else if (runTask.state === taskStatePattern.scheduled) {
         clearTimeout(runTask.taskId);
         runTask.taskId = setTimeout(this.update, apiAccessInterVal, { ...this.note });
@@ -234,8 +227,8 @@ export default {
       // API呼び出し
       this.$store
         .dispatch('note/update', Object.assign(note, { projectId: this.projectId, folderId: note.folderId }))
-        .then(() => {
-          // TODO finallyで実装する
+        .finally(() => {
+          // 成功失敗にかかわらず後処理を実行する
           if (runTask && runTask.state === taskStatePattern.running) {
             // 不要になったタスクを取り除く。
             const newRunTaskStates = this.runTaskStates.filter(rts => rts.noteId !== note.id);
@@ -251,7 +244,6 @@ export default {
           folderId: this.folderId,
         })
         .then(() => {
-          // TODO 同じフォルダのノートの先頭、もしくはフォルダに移動
           // 自分のrootがどこかによって移動先が変わる。
           switch (this.$route.name) {
             case 'NoteInFolder':


### PR DESCRIPTION
…ように修正。

[before: ノートを編集した時、API接続中の場合、一定時間後にAPI呼び出しを実行する　＊排他制御用の値を取得する前に呼び出していたので、排他エラーになっていた]
[After:  ノートを編集した時、API接続中の場合、API接続が完了する(つまり排他制御用の値を受け取る)までAPI呼び出しを実行しない]