### PR TITLE
feat: スマホ画面だとノートの一行目がヘッダーに隠れる #61

### DIFF
--- a/src/components/NavDrawerItem.vue
+++ b/src/components/NavDrawerItem.vue
@@ -1,12 +1,5 @@
 <template>
-  <v-navigation-drawer
-    :value="drawer"
-    color="secondary"
-    floating
-    app
-    style="z-index: 2"
-    @input="$emit('input', $event)"
-  >
+  <v-navigation-drawer :value="drawer" color="secondary" floating app @input="$emit('input', $event)">
     <v-card flat tile height="64px" color="primary" class="overflow-hidden">
       <img class="main-logo ma-4" alt="notenext_logo" src="../assets/logo.png" />
     </v-card>

--- a/src/views/NoteList.vue
+++ b/src/views/NoteList.vue
@@ -1,7 +1,7 @@
 <template>
   <CommonNoteList :projectId="projectId" :searchQuery="searchQuery" :notSelectedNote="!isRouteNote" ref="commonNote">
     <template v-slot:list="{ searchedAlertHeight }">
-      <v-card height="120px" tile class="d-flex flex-column justify-space-between" outlined>
+      <v-card height="120px" tile class="d-flex flex-column justify-space-between" outlined style="z-index: 5">
         <div class="d-flex justify-space-between">
           <v-card-title class="pa-1 folder-name">
             <div class="overflow-text folder-name">


### PR DESCRIPTION
### 原因

ノートの一行目(ヘッダー部分)にz-indexが指定されておらず、逆に全体のヘッダーにはz-indexが指定されていた。

### 対応

ノートの一行目(ヘッダー部分)のz-indexを全体ヘッダーのz-indexと合わせることで、隠れないようにした。